### PR TITLE
Fix typo "You can not install..." => "You can now install..."

### DIFF
--- a/checkio_client/actions/plugin.py
+++ b/checkio_client/actions/plugin.py
@@ -122,7 +122,7 @@ def install(args=None):
     save_install_steps()
     print('Installation Complete!')
     print()
-    print('You can not install browser extension ' + INSTALL_URL)
+    print('You can now install browser extension ' + INSTALL_URL)
     print()
 
 def install_darwin():


### PR DESCRIPTION
Fixes small typo You can **not** install browser extension => You can **now** install browser extension in install-plugin action