### PR TITLE
update aiohttp lib version

### DIFF
--- a/checkio_client/actions/check.py
+++ b/checkio_client/actions/check.py
@@ -93,7 +93,7 @@ def main_check_cio(args):
         if com == 'start_in':
             print('*** ' + block[1] + ' ***' )
         elif com == 'in':
-            if len(block) >= 4 and block[3] and 'assert' in block[3]:
+            if len(block) >= 4 and 'assert' in block[3]:
                 new_version = True
                 print('{} ...'.format(block[3]['assert']), end='')
             else:

--- a/checkio_client/actions/check.py
+++ b/checkio_client/actions/check.py
@@ -93,7 +93,7 @@ def main_check_cio(args):
         if com == 'start_in':
             print('*** ' + block[1] + ' ***' )
         elif com == 'in':
-            if len(block) >= 4 and 'assert' in block[3]:
+            if len(block) >= 4 and block[3] and 'assert' in block[3]:
                 new_version = True
                 print('{} ...'.format(block[3]['assert']), end='')
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 websockets==10.3
 requests==2.28.1
-aiohttp==3.8.1
+aiohttp==3.8.4
 aiohttp-cors==0.7.0
 python-daemon==2.3.0
 pid==3.0.4


### PR DESCRIPTION
For PIP to compile checkio_client under Python 3.11 the aiohttp lib needs an updated version

https://github.com/CheckiO/checkio-client/issues/29