### PR TITLE
requirement.txt update aiohttp lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 websockets==10.3
 requests==2.28.1
-aiohttp==3.8.1
+aiohttp==3.8.4
 aiohttp-cors==0.7.0
 python-daemon==2.3.0
 pid==3.0.4


### PR DESCRIPTION
PIP build fails when using python 3.11. Need aiohttp lib to be updated to ver >= 3.8.4

#29 