### PR TITLE
check.py add test for 'in' block[3]

### DIFF
--- a/checkio_client/actions/check.py
+++ b/checkio_client/actions/check.py
@@ -93,7 +93,7 @@ def main_check_cio(args):
         if com == 'start_in':
             print('*** ' + block[1] + ' ***' )
         elif com == 'in':
-            if len(block) >= 4 and 'assert' in block[3]:
+            if len(block) >= 4 and block[3] and 'assert' in block[3]:
                 new_version = True
                 print('{} ...'.format(block[3]['assert']), end='')
             else:


### PR DESCRIPTION
The checkio_client crashes when trying to check some missions. The code in this PR will prevent the crash.

See: #27 